### PR TITLE
Multiple DS18b20 support

### DIFF
--- a/lib/ds18b20.js
+++ b/lib/ds18b20.js
@@ -6,6 +6,7 @@ var Driver = module.exports = function Driver(opts) {
   Driver.__super__.constructor.apply(this, arguments);
 
   this.device = null;
+  this.many_devices = [];
 
   if (this.pin == null) {
     throw new Error("No pin specified");
@@ -23,8 +24,12 @@ Driver.prototype.start = function(callback) {
       console.error(error);
       return;
     }
-
+    //console.log('Found',devices.length,'devices on the 1-wire bus');
     this.device = devices[0];
+    for (var i in devices) {
+        this.many_devices.push(devices[i]);
+        //console.log('device found:', devices[i]);
+    }
   }.bind(this));
 
   callback();
@@ -36,22 +41,32 @@ Driver.prototype.halt = function(callback) {
 
 Driver.prototype.readTemperature = function(callback) {
   var connection = this.connection,
-    pin = this.pin,
-    device = this.device;
+    pin = this.pin;
+    var devices_local = Object.assign([], this.many_devices);
+    readit(devices_local, readit);
+    function readit(dvss, cb) {
+      var device = dvss.shift();
+      connection.sendOneWireReset(pin);
+      connection.sendOneWireWrite(pin, device, 0x44);
+      connection.sendOneWireDelay(pin, 1000);
+      connection.sendOneWireReset(pin);
+      connection.sendOneWireWriteAndRead(pin, device, 0xBE, 9, function(error, data) {
+        if (error) {
+          callback(error);
+          return;
+        }
 
-  connection.sendOneWireReset(pin);
-  connection.sendOneWireWrite(pin, device, 0x44);
-  connection.sendOneWireDelay(pin, 1000);
-  connection.sendOneWireReset(pin);
-  connection.sendOneWireWriteAndRead(pin, device, 0xBE, 9, function(error, data) {
-    if (error) {
-      callback(error);
-      return;
+        var raw = (data[1] << 8) | data[0],
+          celsius = raw / 16.0;
+
+        callback(null, {device:device, temp:celsius});
+      });
+      if (dvss.length>0) {
+        setTimeout(function () {
+          cb(dvss, cb);
+        }, 1000);
+      }
     }
 
-    var raw = (data[1] << 8) | data[0],
-      celsius = raw / 16.0;
 
-    callback(null, celsius);
-  });
 };


### PR DESCRIPTION
Enables multiple ds18b20 on one port.
This commit changes callback value format from just number to
`{device:device, temp:celsius}`
Where device is ds18b20 sensor identifier as an array. Sample:
`[ 40, 183, 13, 58, 6, 0, 0, 242 ]`